### PR TITLE
Stop loading entire compressed npy into memory

### DIFF
--- a/include/xtensor-io/xnpz.hpp
+++ b/include/xtensor-io/xnpz.hpp
@@ -111,7 +111,13 @@ namespace xt
             }
             else
             {
-                zstr::istream zstream(stream, compr_bytes);
+                if (compr_bytes == 0xffffffff)
+                {
+                    throw std::runtime_error("load_npz: ZIP64 is not implemented");
+                }
+
+                auto pos = stream.tellg();
+                zstr::istream zstream(stream);
 
                 if (!zstream)
                 {
@@ -120,6 +126,7 @@ namespace xt
 
                 arrays.insert(result_type::value_type(varname,
                                                       detail::load_npy_file(zstream)));
+                stream.seekg(pos + std::streamoff(compr_bytes));
             }
         }
         return arrays;
@@ -199,7 +206,13 @@ namespace xt
                 }
                 else
                 {
-                    zstr::istream zstream(stream, compr_bytes);
+                    if (compr_bytes == 0xffffffff)
+                    {
+                        throw std::runtime_error("load_npz: ZIP64 is not implemented");
+                    }
+
+                    auto pos = stream.tellg();
+                    zstr::istream zstream(stream);
 
                     if (!zstream)
                     {
@@ -207,6 +220,7 @@ namespace xt
                     }
 
                     detail::npy_file f = detail::load_npy_file(zstream);
+                    stream.seekg(pos + std::streamoff(compr_bytes));
                     return f.cast<T>();
                 }
             }


### PR DESCRIPTION
The second parameter of `zstr::istream` ctor is buffer size (defaults to 1MB), not stream size, therefore `load_npz` overloads will load the entire compressed npy data into memory (up to 4GB), then decompress.  This has a side effect, that is: if an entry is not using ZIP64, `zstream` will not read the underlying `stream` pass the starting position of the next entry.  If the entry is using ZIP64, it just fails randomly.

The fix stops using the compressed size as buffer size.  It simply remembers where the current entry stops, and rewind `stream` back to where the next entry starts.  And it has an explicit check for compressed ZIP64 entry and admits that we don't currently support it.